### PR TITLE
Fix/implement timer triggers for updates

### DIFF
--- a/createtable/function.json
+++ b/createtable/function.json
@@ -5,7 +5,7 @@
       "name": "monthlyTimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 10 1 */1 *"
+      "schedule": "0 0 11 1 * *"
     },
     {
       "name": "prsIn",

--- a/dailymessage/__init__.py
+++ b/dailymessage/__init__.py
@@ -1,12 +1,22 @@
+import logging
+from datetime import datetime, timezone
+
 import azure.functions as func
 
 from dailymessage.daily_slack_message import send_daily_slack_message
 from utils.filter import load_jsonl_string_into_df
 
 
-def main(prsStream: func.InputStream, projectsIn: str, contributorsIn: str) -> None:
-    prs = load_jsonl_string_into_df(prsStream.read().decode("utf-8"))
+def main(
+    dailyTimer: func.TimerRequest, prsIn: str, projectsIn: str, contributorsIn: str
+) -> None:
+    utc_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+    if dailyTimer.past_due:
+        logging.info("The timer is past due!")
+
+    prs = load_jsonl_string_into_df(prsIn)
     projects = load_jsonl_string_into_df(projectsIn)
     contributors = load_jsonl_string_into_df(contributorsIn)
 
     send_daily_slack_message(prs, projects, contributors)
+    logging.info("Python timer trigger function ran at %s", utc_timestamp)

--- a/dailymessage/function.json
+++ b/dailymessage/function.json
@@ -2,8 +2,15 @@
   "scriptFile": "__init__.py",
   "bindings": [
     {
-      "name": "prsStream",
-      "type": "blobTrigger",
+      "name": "dailyTimer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 0 10 * * *"
+    },
+    {
+      "name": "prsIn",
+      "type": "blob",
+      "dataType": "string",
       "direction": "in",
       "path": "data/pullrequests.jsonl",
       "connection": "AzureWebJobsStorage"

--- a/sendtable/__init__.py
+++ b/sendtable/__init__.py
@@ -1,8 +1,17 @@
+import logging
+from datetime import datetime, timezone
+
 import azure.functions as func
 
 from sendtable.monthly_pr_table import image_bytes_to_buffer, send_monthly_pr_table
 
 
-def main(tableBlob: func.InputStream) -> None:
-    table_buffer = image_bytes_to_buffer(tableBlob.read())
+def main(monthlyTimer: func.TimerRequest, tableIn: bytes) -> None:
+    utc_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+
+    if monthlyTimer.past_due:
+        logging.info("The timer is past due!")
+
+    table_buffer = image_bytes_to_buffer(tableIn)
     send_monthly_pr_table(table_buffer)
+    logging.info("Python timer trigger function ran at %s", utc_timestamp)

--- a/sendtable/function.json
+++ b/sendtable/function.json
@@ -2,9 +2,16 @@
   "scriptFile": "__init__.py",
   "bindings": [
     {
-      "name": "tableBlob",
-      "type": "blobTrigger",
+      "name": "monthlyTimer",
+      "type": "timerTrigger",
       "direction": "in",
+      "schedule": "0 0 12 1 * *"
+    },
+    {
+      "name": "tableIn",
+      "type": "blob",
+      "direction": "in",
+      "dataType": "binary",
       "path": "tables/pull_requests.png",
       "connection": "AzureWebJobsStorage"
     }


### PR DESCRIPTION
daily message and send table are now triggered by a timer. The timers are set such that slack messages are sent after the resources have been updated.