### PR TITLE
Increase function time limit to 10 minutes

### DIFF
--- a/host.json
+++ b/host.json
@@ -15,5 +15,6 @@
   "concurrency": {
     "dynamicConcurrencyEnabled": true,
     "snapshotPersistenceEnabled": true
-  }
+  },
+  "functionTimeout": "00:10:00"
 }


### PR DESCRIPTION
The default time limit for function executions is 5 minutes. This change sets that to the maximum for consumption plan apps of 10 minutes.